### PR TITLE
Set CMake min. version to a range, 3.2...3.12: support CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.12)
 #allow using of HDF5_ROOT for building with a custom HDF5 version
 cmake_policy(SET CMP0074 NEW)
 project(MorphIO VERSION 2.0.0)


### PR DESCRIPTION
CMake 4.0 drops support for CMake <3.5, so minimum versions need to be adjusted for forward compatibility. Since CMake <3.10 is [already deprecated](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9875), and 3.12 is the first “modern” CMake release, let’s support policy versions up to 3.12.

Setting `3.2...3.12` says: the project requires at least 3.2 but has been updated to work with policies introduced by 3.12 or earlier. See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html.

(We could also just set the minimum version to 3.12, which is available in all known currently-supported Linux distributions.)