### PR TITLE
Update gsl-lite to 1.0.1

### DIFF
--- a/include/morphio/vector_types.h
+++ b/include/morphio/vector_types.h
@@ -1,15 +1,26 @@
 #pragma once
 
+#if !gsl_CONFIG_ALLOWS_SPAN_COMPARISON
+#include <algorithm>
+#endif
 #include <array>
 #include <cmath>  // M_PI
 #include <vector>
 
-#include <gsl/gsl-lite.hpp>
+#include <gsl-lite/gsl-lite.hpp>
 
 namespace morphio {
 
 template <typename T>
-using range = gsl::span<T>;
+using range = gsl_lite::span<T>;
+
+#if !gsl_CONFIG_ALLOWS_SPAN_COMPARISON
+template <typename T>
+inline bool operator==(morphio::range<T> l, morphio::range<T> r) {
+    return l.size() == r.size() &&
+           (l.data() == r.data() || std::equal(l.begin(), l.end(), r.begin()));
+}
+#endif
 
 #ifdef MORPHIO_USE_DOUBLE
 using floatType = double;

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <catch2/catch.hpp>
-#include <gsl/gsl-lite.hpp>
+#include <gsl-lite/gsl-lite.hpp>
 #include <morphio/version.h>
 
 #include <filesystem>


### PR DESCRIPTION
See https://github.com/gsl-lite/gsl-lite/releases/tag/v1.0.0 and https://gsl-lite.github.io/gsl-lite/#migration-guide.

In gsl-lite 1.x, `gsl_CONFIG_ALLOWS_SPAN_COMPARISON` defaults to 0, so I implemented it manually for `morphio::range`.